### PR TITLE
Write files for release to single directory

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -5,3 +5,6 @@ WORKSPACE_DIR = pathlib.Path(__file__).parents[1]
 ANALYSIS_DIR = WORKSPACE_DIR / "analysis"
 
 OUTPUT_DIR = WORKSPACE_DIR / "output"
+
+# Output and supporting files/dirs for release
+RELEASE_DIR = OUTPUT_DIR / "files_for_release"

--- a/analysis/generate_dummy_rows.py
+++ b/analysis/generate_dummy_rows.py
@@ -6,11 +6,11 @@ opensafely exec python:latest python -m analysis.generate_dummy_rows
 
 import pandas
 
-from analysis import utils
+from analysis import OUTPUT_DIR, utils
 
 
 def main():
-    f_out = utils.OUTPUT_DIR / "generate_dummy_rows" / "dummy_rows.csv.gz"
+    f_out = OUTPUT_DIR / "generate_dummy_rows" / "dummy_rows.csv.gz"
     table_names = [
         "APCS",
         "CPNS",

--- a/analysis/latest_import_dates.py
+++ b/analysis/latest_import_dates.py
@@ -2,14 +2,14 @@
 
 import pandas
 
-from analysis import utils
+from analysis import OUTPUT_DIR, RELEASE_DIR, utils
 
 
 def main():
-    f_in = utils.OUTPUT_DIR / "query" / "rows.csv.gz"
+    f_in = OUTPUT_DIR / "query" / "rows.csv.gz"
     latest_import_dates = get_latest_import_dates(f_in)
 
-    f_out = utils.OUTPUT_DIR / "latest_import_dates" / "latest_import_dates.csv"
+    f_out = RELEASE_DIR / "latest_import_dates.csv"
     utils.makedirs(f_out.parent)
     latest_import_dates.to_csv(f_out)
 

--- a/analysis/query.sql
+++ b/analysis/query.sql
@@ -3,4 +3,5 @@
 SELECT
     BuildDesc AS build_desc,
     CONVERT(DATE, BuildDate) AS build_date
-FROM BuildInfo ORDER BY build_desc, build_date
+FROM BuildInfo
+ORDER BY build_desc, build_date

--- a/analysis/render_report.py
+++ b/analysis/render_report.py
@@ -11,7 +11,7 @@ import mimetypes
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
-from analysis import ANALYSIS_DIR, utils
+from analysis import ANALYSIS_DIR, OUTPUT_DIR, RELEASE_DIR, utils
 
 ENVIRONMENT = Environment(
     loader=FileSystemLoader(ANALYSIS_DIR),
@@ -20,15 +20,15 @@ ENVIRONMENT = Environment(
 
 
 def main():
-    f_out = utils.OUTPUT_DIR / "render_report" / "report.html"
+    f_out = RELEASE_DIR / "report.html"
     utils.makedirs(f_out.parent)
     rendered_report = render_report(
         {
             "run_date": utils.get_run_date(),
             "latest_import_dates": get_latest_import_dates(
-                utils.OUTPUT_DIR / "latest_import_dates" / "latest_import_dates.csv"
+                RELEASE_DIR / "latest_import_dates.csv"
             ),
-            "plot": utils.OUTPUT_DIR / "plot" / "plot.png",
+            "plot": OUTPUT_DIR / "plot" / "plot.png",
         }
     )
     f_out.write_text(rendered_report, encoding="utf-8")

--- a/project.yaml
+++ b/project.yaml
@@ -22,7 +22,7 @@ actions:
     run: python:latest python -m analysis.latest_import_dates
     outputs:
       moderately_sensitive:
-        latest_import_dates: output/latest_import_dates/latest_import_dates.csv
+        latest_import_dates: output/files_for_release/latest_import_dates.csv
 
   plot:
     needs: [query]
@@ -36,4 +36,4 @@ actions:
     run: python:latest python -m analysis.render_report
     outputs:
       moderately_sensitive:
-        report: output/render_report/report.html
+        report: output/files_for_release/report.html


### PR DESCRIPTION
To allow us to automate release requests for this workspace, write the file to be released (report.html) and the supporting file (latest_import_dates.csv)
to the same containing directory. This means we can set up the release request so that both output and supporting files are added to the same group.

Fixes #138 

Requires [Airlock PR](https://github.com/opensafely-core/airlock/pull/1042) to allow supporting files before the actual automated release can be set up.