### PR TITLE
Point users to coverage report

### DIFF
--- a/analysis/report_template.html
+++ b/analysis/report_template.html
@@ -41,10 +41,12 @@
         Once a data source has been imported,
         it can be queried immediately from <a href="https://docs.opensafely.org/security-levels/#level-3">Level 3</a>.
     </p>
-    <p>
+    <p class="bg-yellow-50 border-l-4 border-yellow-400 p-4">
         The dates in the sections below reflect when the data sources were last imported into the OpenSAFELY-TPP database.
         They do not reflect when the data sources were received by TPP,
         nor when the event activity occurred.
+        For more information on the date coverage of events in these data sources,
+        see the <a href="https://reports.opensafely.org/reports/opensafely-tpp-database-history/">Database Coverage Report</a>
     </p>
     <h3>Latest Import Dates</h3>
     <table>


### PR DESCRIPTION
Users have reportedly been misinterpreting the import dates in this report as date coverage for the underlying events, despite the pre-existing warning.

This change highlights the warning and provides a link to the database coverage report where the date coverage can be found.